### PR TITLE
FIX-4: Fixed logical error in description of action

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -280,7 +280,7 @@ function printConfirmation()
     fi
     if [ "${MAGENTO_EE_PATH}" ]
     then
-        printString "Magento EE will be installed to ${MAGENTO_EE_PATH}"
+        printString "Magento EE will be installed from ${MAGENTO_EE_PATH}"
     else
         printString "Magento EE will NOT be installed."
     fi


### PR DESCRIPTION
I've found, that phrase
`Magento EE will be installed to ./ee`
is not correct, because **./ee**, in this case, was specified as a source of EE code.
So, I think that it should be changed to
`Magento EE will be installed from ./ee`
Thank you.