### PR TITLE
Disable SSL flag for frontend and admin to prevent infinite redirect

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -501,6 +501,7 @@ function configure_db()
     updateBaseUrl
     clearBaseLinks
     clearCookieDomain
+    clearSslFlag
     clearCustomAdmin
     resetAdminPassword
 }
@@ -520,6 +521,12 @@ function clearBaseLinks()
 function clearCookieDomain()
 {
     SQLQUERY="DELETE FROM ${DB_NAME}.${TBL_PREFIX}core_config_data WHERE path = 'web/cookie/cookie_domain'"
+    mysqlQuery
+}
+
+function clearSslFlag()
+{
+    SQLQUERY="UPDATE ${DB_NAME}.${TBL_PREFIX}core_config_data AS e SET e.value = 0 WHERE e.path IN ('web/secure/use_in_adminhtm', 'web/secure/use_in_frontend')"
     mysqlQuery
 }
 


### PR DESCRIPTION
M2install replaces both values for 'web/secure/base_url', 'web/unsecure/base_url' to 'http://' URL , but, for example, when 'web/secure/use_in_adminhtml' set to 1 you get infinite loop redirect on admin login form.