### PR TITLE
Fix for a slash count for tar command caused by OSX wc output formatting

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -217,7 +217,7 @@ function getStripComponentsValue()
 {
     local stripComponents=
     local slashCount=
-    slashCount=$(tar -tf "$1" | grep -v vendor | fgrep pub/index.php | sed 's/pub[/]index[.]php//' | sort | head -1 | tr -cd '/' | wc -c)
+    slashCount=$(tar -tf "$1" | grep -v vendor | fgrep pub/index.php | sed 's/pub[/]index[.]php//' | sort | head -1 | tr -cd '/' | wc -m | tr ' ')
 
     if [[ "$slashCount" -gt 0 ]]
     then


### PR DESCRIPTION
In current implementation on OS X
tar -tf "$1" | grep -v vendor | fgrep pub/index.php | sed 's/pub[/]index[.]php//' | sort | head -1 | tr -cd '/' | wc -c
would produce a wrong resulting command because of wc output formatting
tar --strip-components=       1 -xf ./......