### PR TITLE
Enabling the flags for elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Options:
     --restore-table                      Restore only the specific table from DB dumps
     --debug                              Enable debug mode
     --php                                Specify path to PHP CLI (php71 or /usr/bin/php71)
+    --es-host, --elasticsearch-host      Set the Elasticsearch host
+    --es-port, --elasticsearch-port      Set the Elasticsearch port
     _________________________________________________________________________________________________
     --ee-path (/path/to/ee)              (DEPRECATED use --ee flag) Path to Enterprise Edition.
 ```

--- a/m2install.sh
+++ b/m2install.sh
@@ -884,6 +884,7 @@ function configure_db()
   setConfig 'msp_securitysuite_twofactorauth/general/enabled' '0';
   setConfig 'msp_securitysuite_recaptcha/backend/enabled' '0';
   setConfig 'msp_securitysuite_recaptcha/frontend/enabled' '0';
+  setConfig 'admin/security/session_lifetime' '31536000';
   setConfig 'admin/startup/menu_item_id' 'Magento_Backend::system_store';
   deleteConfig 'web/unsecure/base_link_url';
   deleteConfig 'web/secure/base_link_url';

--- a/m2install.sh
+++ b/m2install.sh
@@ -29,6 +29,10 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=
 
+
+ELASTICSEARCH_HOST=
+ELASTICSEARCH_PORT=
+
 MAGENTO_VERSION=2.2
 
 DB_NAME=
@@ -478,6 +482,22 @@ function printConfirmation()
     else
         printString "Magento B2B will NOT be installed."
     fi
+    if [[ "$ELASTICSEARCH_HOST" ]]
+    then  
+        printString " "
+        printString "========================= Checking Elasticsearch ========================="
+        printString "ELASTICSEARCH HOST: ${ELASTICSEARCH_HOST}"
+        printString "ELASTICSEARCH PORT: ${ELASTICSEARCH_PORT}"
+        curl ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT} | grep 'You Know, for Search'
+        tagline=$?
+        if [ 0 = $tagline ]
+            then
+                printString "========================= Elasticsearch Found ========================="
+            else
+                printString " =========================> ELASTICSEARCH NOT FOUND!!! <========================= "
+        fi
+        printString " "
+    fi
 }
 
 function showWizard()
@@ -579,6 +599,8 @@ REMOTE_KEY=$REMOTE_KEY
 LOCAL_PORT=$LOCAL_PORT
 REMOTE_DB=$REMOTE_DB
 REMOTE_DB_PASSWORD=$REMOTE_DB_PASSWORD
+ELASTICSEARCH_HOST=$ELASTICSEARCH_HOST
+ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT
 EOF
 )
 
@@ -1338,6 +1360,9 @@ function installMagento()
     if [ "${DB_PASSWORD}" ]; then
         CMD="${CMD} --db-password=${DB_PASSWORD}"
     fi
+    if [ "${ELASTICSEARCH_HOST}" ]; then
+        CMD="${CMD} --elasticsearch-host=${ELASTICSEARCH_HOST} --elasticsearch-port=${ELASTICSEARCH_PORT}"
+    fi
     runCommand
 }
 
@@ -1651,6 +1676,8 @@ Options:
     --debug                              Enable debug mode
     --php                                Specify path to PHP CLI (php71 or /usr/bin/php71)
     --remote-db                          Remote database name
+    --es-host, --elasticsearch-host      Set the Elasticsearch host
+    --es-port, --elasticsearch-port      Set the Elasticsearch port
     _________________________________________________________________________________________________
     --ee-path (/path/to/ee)              (DEPRECATED use --ee flag) Path to Enterprise Edition.
 EOF
@@ -1771,6 +1798,16 @@ function processOptions()
             --remote-db)
                 checkArgumentHasValue "$1" "$2"
                 REMOTE_DB=$2
+                shift
+            ;;
+            --es-host|--elasticsearch-host)
+                checkArgumentHasValue "$1" "$2"
+                ELASTICSEARCH_HOST=$2
+                shift
+            ;;
+            --es-port|--elasticsearch-port)
+                checkArgumentHasValue "$1" "$2"
+                ELASTICSEARCH_PORT=$2
                 shift
             ;;
         esac


### PR DESCRIPTION
This change allows to install Magento 2.4 using the command:
`m2install.sh -s composer -v 2.4.0 --es-host http://magento2elastic7 --es-port 9207`

For the dumps, the elasticsearch configuration still have to set up manually inside Magento admin panel

This change is not affecting the wizard <-- TODO