### PR TITLE
Need to add one more grep -v to exclude another error message from th…

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -749,7 +749,7 @@ function restore_db()
     CMD="${CMD} | gunzip -cf | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/'
         | sed -e 's/TRIGGER[ ][\`][A-Za-z0-9_]*[\`][.]/TRIGGER /'
         | sed -e 's/AFTER[ ]\(INSERT\)\{0,1\}\(UPDATE\)\{0,1\}\(DELETE\)\{0,1\}[ ]ON[ ][\`][A-Za-z0-9_]*[\`][.]/AFTER \1\2\3 ON /'
-        | grep -v 'mysqldump: Couldn.t find table' | grep -v 'Warning: Using a password'
+        | grep -v 'mysqldump: Couldn.t find table' | grep -v 'mysqldump: Couldn.t execute' | grep -v 'Warning: Using a password'
         | ${BIN_MYSQL} -h${DB_HOST} -u${DB_USER} --password=\"${DB_PASSWORD}\" --force $DB_NAME";
     runCommand
 


### PR DESCRIPTION
…e mysql dump file

We started to see the m2install failed due to  below error messages
```
pv "./php74.database.sql.gz" | gunzip -cf | gunzip -cf | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/'
| sed -e 's/TRIGGER[ ][`][A-Za-z0-9_]*[`][.]/TRIGGER /'
| sed -e 's/AFTER[ ]\(INSERT\)\{0,1\}\(UPDATE\)\{0,1\}\(DELETE\)\{0,1\}[ ]ON[ ][`][A-Za-z0-9_]*[`][.]/AFTER \1\2\3 ON /'
| grep -v 'mysqldump: Couldn.t find table' | grep -v 'Warning: Using a password'
| mysql -hdb.us-west-2.prd.sparta.ceng.magento.com -uhawi --password="Uz5AXJZWMF3TF_34" --force hawi_492563
ERROR at line 616782: Unknown command '\"'.======================================================================================> ] 64% ETA 0:02:10
ERROR at line 616782: Unknown command '\"'.
```


This was because the below error was seen in the actual line (616782 in above example):
```
mysqldump: Couldn't execute 'SHOW FIELDS FROM `inventory_stock_1`': View 'shortys.inventory_stock_1' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them (1356)
```

So "grep -v 'mysqldump: Couldn.t execute'" should address it.