### PR TITLE
Added getTablePrefix to validating db dump

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -764,7 +764,7 @@ function restore_db()
 function validateDatabaseDumpDataExists()
 {
   local isError=
-  if [ -z "$(getAllTables 'store')" ]
+  if [ -z "$(getAllTables \"$(getTablePrefix)store\")" ]
   then
     printError "The store table is not found"
     isError="1"


### PR DESCRIPTION
Fixed the issue when the store uses tables prefix and the installation exits with the error:
```
The store table is not found
```