### PR TITLE
L2ACIP-335: fix Magento version parsing regex

### DIFF
--- a/.github/.metadata.json
+++ b/.github/.metadata.json
@@ -1,0 +1,25 @@
+{
+    "templateVersion": "0.2",
+    "product": {
+        "name": "GDPR Helper",
+        "description": "The tool that helps to remove sensetive data per GDPR policy",
+    },
+    "contacts": {
+        "team": {
+            "name": "Adobe Commerce Support Developers",
+            "DL": "Grp-Magento-Support-Engineering",
+            "slackChannel": "#support-engineering"
+        }
+    },
+    "ticketTracker": {
+        "functionalJiraQueue": {
+            "projectKey": "ACSD",
+            "component": ""
+        },
+        "securityJiraQueue": {
+            "projectKey": "ACSD",
+            "component": "ACSD"
+        }
+    },
+    "productionCodeBranches": ["master"]
+}

--- a/.github/.metadata.json
+++ b/.github/.metadata.json
@@ -1,8 +1,8 @@
 {
     "templateVersion": "0.2",
     "product": {
-        "name": "GDPR Helper",
-        "description": "The tool that helps to remove sensetive data per GDPR policy",
+        "name": "Magento 2 Bash Install/Restore Script",
+        "description": "Script simplifies  the installation process of Magento 2 and rapid deployment of merchant code and DB dumps",
     },
     "contacts": {
         "team": {

--- a/m2install.sh
+++ b/m2install.sh
@@ -93,7 +93,7 @@ M2INSTALL_CSV_LOG=${M2INSTALL_CSV_LOG:-}
 
 function printVersion()
 {
-    printString "1.0.5"
+    printString "1.0.6"
 }
 
 function getScriptDirectory()
@@ -1246,6 +1246,7 @@ function setPaymentConfigToInactive()
   setConfig 'payment/payflowpro/active' '0';
   setConfig 'payment/paypal_payment_pro/active' '0';
   setConfig 'payment/payflow_link/active' '0';
+  setConfig 'payment/stripe_payments/active' '0';
 }
 
 function deletePaymentConfig()
@@ -1312,6 +1313,7 @@ function removeConfigByKeyword()
   deleteConfig '%secret%' 'LIKE';
   deleteConfig '%application_key%' 'LIKE';
   deleteConfig '%token%' 'LIKE';
+  deleteConfig '%payment/stripe%' 'LIKE';
 }
 
 function resetAdminPassword()

--- a/m2install.sh
+++ b/m2install.sh
@@ -2518,18 +2518,6 @@ function versionIsHigherThan()
 
 }
 
-function versionIsHigherThan()
-{
-  local defaultVersion="2.4"
-  local mageVersion="$MAGENTO_VERSION"
-  [[ "$1" ]] && mageVersion="$1"
-  [[ "$2" ]] && defaultVersion="$2"
-  local esRequired=$(php -r "echo (version_compare('$mageVersion', '$defaultVersion') >= 0) ? 'REQUIRED' : 'NO';")
-  [[ "$esRequired" == "REQUIRED" ]] && return 0;
-  return 1;
-
-}
-
 function validateElasticSearchIsAvailable()
 {
   [[ ! "$ELASTICSEARCH_HOST" ]] && ELASTICSEARCH_HOST="$(getESConfigHost $(getRecommendedSearchEngineForVersion))"
@@ -2848,4 +2836,3 @@ function main()
     printString "Pass: ${ADMIN_PASSWORD}"
 }
 main "${@}"
-

--- a/m2install.sh
+++ b/m2install.sh
@@ -1041,6 +1041,23 @@ index d419c25..eab39a4 100644
 
      /**
 EOF
+  # Fix "Undefined array key 'frontend'" error
+  # https://wiki.corp.adobe.com/pages/viewpage.action?pageId=2820824435
+  patch -p1 <<'EOF'
+diff --git a/vendor/magento/framework/App/Cache/Frontend/Pool.php b/vendor/magento/framework/App/Cache/Frontend/Pool.php
+index 6571ba7..0551b9f 100644
+--- a/vendor/magento/framework/App/Cache/Frontend/Pool.php
++++ b/vendor/magento/framework/App/Cache/Frontend/Pool.php
+@@ -86,7 +86,7 @@ class Pool implements \Iterator
+          * default cache_dir setting from di.xml when a cache id_prefix is configured in app/etc/env.php.
+          */
+         $cacheInfo = $this->deploymentConfig->getConfigData(FrontendPool::KEY_CACHE);
+-        if (null !== $cacheInfo && array_key_exists(FrontendPool::KEY_FRONTEND_CACHE, $cacheInfo)) {
++       if (null !== $cacheInfo && isset($cacheInfo[FrontendPool::KEY_FRONTEND_CACHE])) {
+             return array_replace_recursive($this->_frontendSettings, $cacheInfo[FrontendPool::KEY_FRONTEND_CACHE]);
+         }
+         return $this->_frontendSettings;
+EOF
 }
 
 function appConfigImport()

--- a/m2install.sh
+++ b/m2install.sh
@@ -1179,7 +1179,6 @@ function configure_db()
   setConfig 'web/secure/base_url' "${BASE_URL}";
   setConfig 'web/unsecure/base_url' "${BASE_URL}";
   setConfig 'web/secure/offloader_header' 'X-Forwarded-Proto';
-  setConfig 'web/seo/use_rewrites' '1';
   setConfig 'google/analytics/active' '0';
   setConfig 'google/adwords/active' '0';
   setConfig 'msp_securitysuite_twofactorauth/general/enabled' '0';
@@ -1222,6 +1221,7 @@ function configure_db()
   resetAdminPassword
   switchSearchEngineToDefaultEngine
 
+  ${BIN_PHP} ${BIN_MAGE} config:set 'web/seo/use_rewrites' '1'
   ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_admin' '0'
   ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_storefront' '0'
 }

--- a/m2install.sh
+++ b/m2install.sh
@@ -1740,7 +1740,11 @@ function getB2Bversion()
     MAGENTO_MAJOR_VERSION=`echo "${REAL_MAGENTO_VERSION}" | sed 's/.*2\.\([0-9]*\)\.\([0-9]*\).*/\1/'`
     MAGENTO_MINOR_VERSION=`echo "${REAL_MAGENTO_VERSION}" | sed 's/.*2\.\([0-9]*\)\.\([0-9]*\).*/\2/'`
     MAGENTO_PATCH_VERSION=`echo "${REAL_MAGENTO_VERSION}" | sed 's/.*2\.\([0-9]*\)\.\([0-9]*\).\([a-z0-9]*\)/\3/'`
-    if [ $MAGENTO_MAJOR_VERSION -ge 4 ] && [ $MAGENTO_MINOR_VERSION -ge 1 ]
+    if [ $MAGENTO_MAJOR_VERSION -eq 4 ] && [ $MAGENTO_MINOR_VERSION -eq 7 ]
+    then
+        B2B_VERSION_MAJOR='4'
+        B2B_VERSION_MINOR='2'
+    elif [ $MAGENTO_MAJOR_VERSION -ge 4 ] && [ $MAGENTO_MINOR_VERSION -ge 1 ]
     then
         B2B_VERSION_MAJOR=$(( `echo "${MAGENTO_MAJOR_VERSION}"` -1 ))
         B2B_VERSION_MINOR=$(( `echo "${MAGENTO_MINOR_VERSION}"` -1 ))

--- a/m2install.sh
+++ b/m2install.sh
@@ -2486,10 +2486,16 @@ function cleanupCurrentDirectory()
     printError "Current Directory is home ($currentDirectory)"
     exit 1;
   fi
-  if [ "$(ls -A)" ] && askConfirmation "Current directory is not empty. Do you want to clean current Directory (y/N)"
+  if [ "$(ls -A)" ] && askConfirmation "Current directory is not empty. Do you want to clean current Directory (y/N)";
   then
-    CMD="ls -A | xargs rm -rf"
-    runCommand
+    if askConfirmation "Do you want to delete dump files? (y/N)";
+    then
+      CMD="ls -A | xargs rm -rf"
+      runCommand
+    else
+      CMD="ls -I 'php*.*.*gz' -A | xargs rm -rf"
+      runCommand
+    fi
   fi
 }
 function versionIsHigherThan()

--- a/m2install.sh
+++ b/m2install.sh
@@ -2820,6 +2820,31 @@ function testParseMagentoVersion()
   assertEqual "2.2.4-p10" "$result"
 }
 
+validateWorkDirectory() {
+  # Exit if the script runs inside a home directory
+  if [[ ${PWD} == ${HOME} ]]; then
+    echo "The script cannot be executed in home directory"
+    echo "Please create a subdirectory and run script from there"
+    exit 1
+  fi
+
+  # Sparta specific checks
+  if [[ ${HOSTNAME} =~ sparta.ceng.magento.com$ ]]; then
+    # Exit if the script runs outside of public_html directory
+    if [[ ! ${PWD} =~ ^${HOME}/public_html* ]]; then
+      echo "The script cannot be executed outside of public_html directory"
+      echo "Please create a subdirectory in ${HOME}/public_html and run script from there"
+      exit 1
+    fi
+
+    # Exit if the script runs inside public_html directory without a subfolder
+    if [[ ${PWD} == ${HOME}/public_html ]]; then
+      echo "The script cannot be executed in public_html directory"
+      echo "Please create a subdirectory and run script from there"
+      exit 1
+    fi
+  fi
+}
 
 ################################################################################
 # Main
@@ -2840,6 +2865,7 @@ function main()
     processOptions "$@"
     initQuietMode
     printString Current Directory: "$(pwd)"
+    validateWorkDirectory
     printString "Configuration loaded from: $(getConfigFiles)"
     checkDependencies
     showWizard

--- a/m2install.sh
+++ b/m2install.sh
@@ -1221,6 +1221,9 @@ function configure_db()
   removeConfigByKeyword
   resetAdminPassword
   switchSearchEngineToDefaultEngine
+
+  ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_admin' '0'
+  ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_storefront' '0'
 }
 
 function setConfig()

--- a/m2install.sh
+++ b/m2install.sh
@@ -807,7 +807,7 @@ function restore_db()
 
     if [[ "${_DB_FILENAME}" =~ "db_mydumper.sql.gz" ]]; then
         hash myloader &>/dev/null || printError "'myloader' is not found on this system" || exit 1
-        CMD="gunzip -cf ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
+        CMD="gunzip -cf ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password=\"${DB_PASSWORD}\" --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
     else
         CMD="gunzip -cf ${_DB_FILENAME}"
         if which pv > /dev/null

--- a/m2install.sh
+++ b/m2install.sh
@@ -2804,6 +2804,31 @@ function testParseMagentoVersion()
   assertEqual "2.2.4-p10" "$result"
 }
 
+validateWorkDirectory() {
+  # Exit if the script runs inside a home directory
+  if [[ ${PWD} == ${HOME} ]]; then
+    echo "The script cannot be executed in home directory"
+    echo "Please create a subdirectory and run script from there"
+    exit 1
+  fi
+
+  # Sparta specific checks
+  if [[ ${HOSTNAME} =~ sparta.ceng.magento.com$ ]]; then
+    # Exit if the script runs outside of public_html directory
+    if [[ ! ${PWD} =~ ^${HOME}/public_html* ]]; then
+      echo "The script cannot be executed outside of public_html directory"
+      echo "Please create a subdirectory in ${HOME}/public_html and run script from there"
+      exit 1
+    fi
+
+    # Exit if the script runs inside public_html directory without a subfolder
+    if [[ ${PWD} == ${HOME}/public_html ]]; then
+      echo "The script cannot be executed in public_html directory"
+      echo "Please create a subdirectory and run script from there"
+      exit 1
+    fi
+  fi
+}
 
 ################################################################################
 # Main
@@ -2824,6 +2849,7 @@ function main()
     processOptions "$@"
     initQuietMode
     printString Current Directory: "$(pwd)"
+    validateWorkDirectory
     printString "Configuration loaded from: $(getConfigFiles)"
     checkDependencies
     showWizard

--- a/m2install.sh
+++ b/m2install.sh
@@ -1987,13 +1987,18 @@ function downloadSourceCode()
 
 function composerInstall()
 {
-    if [ "$INSTALL_EE" ]
-    then
-        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition . ${MAGENTO_VERSION}"
-        runCommand
+    if [ "$INSTALL_EE" ]; then
+        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-enterprise-edition ./ "${MAGENTO_VERSION}"
+        if (( $? != 0 )); then
+            echo "Failed to create a composer project"
+            exit 1
+        fi
     else
-        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-community-edition . ${MAGENTO_VERSION}"
-        runCommand
+        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-community-edition ./ "${MAGENTO_VERSION}"
+        if (( $? != 0 )); then
+            echo "Failed to create a composer project"
+            exit 1
+        fi
     fi
 }
 

--- a/m2install.sh
+++ b/m2install.sh
@@ -2262,6 +2262,7 @@ function afterInstall()
 
 function disableTwoFactorAuthModules()
 {
+    disableModule 'Magento_AdminAdobeImsTwoFactorAuth'
     disableModule 'Magento_TwoFactorAuth'
     disableModule 'MarkShust_DisableTwoFactorAuth'
     disableModule 'WolfSellers_EnableDisableTfa'

--- a/m2install.sh
+++ b/m2install.sh
@@ -1837,7 +1837,14 @@ function installMagento()
       searchEngineBase="${searchEngine%[[:digit:]]}"
       CMD="${CMD} --search-engine=$searchEngine --${searchEngineBase}-host=$(getESConfigHost $searchEngine) --${searchEngineBase}-port=$(getESConfigPort $searchEngine) --${searchEngineBase}-index-prefix=${DB_NAME}"
     fi
-    runCommand
+
+    echo "${CMD}"
+    ${CMD}
+    if (( $? != 0 )); then
+      echo "bin/magento setup:install failed"
+      exit 1
+    fi
+
 }
 
 function isElasticSearchRequired()

--- a/m2install.sh
+++ b/m2install.sh
@@ -996,8 +996,8 @@ index 5027978..9df3c24 100644
      protected function _afterLoadCollection()
      {
          foreach ($this->getCollection() as $item) {
-+            // patched by m2install.
-+            // To revert patch remove next lines from 95 to 99
++            // patched by m2install
++            // To revert the patch remove the next 3 lines
 +            if (is_null($item->getBillingAddress())) {
 +                return $this;
 +            }
@@ -1013,12 +1013,15 @@ diff -Nuar a/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php b/vendo
 index 1f454518e43..b3dcc784917 100644
 --- a/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
 +++ b/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
-@@ -29,7 +29,7 @@ class PhpCookieManager implements CookieManagerInterface
+@@ -29,7 +29,10 @@ class PhpCookieManager implements CookieManagerInterface
       * RFC 2109 - Page 15
       * http://www.ietf.org/rfc/rfc6265.txt
       */
 -    const MAX_NUM_COOKIES = 50;
 -    const MAX_COOKIE_SIZE = 4096;
++    // patched by m2install
++    //const MAX_NUM_COOKIES = 50;
++    //const MAX_COOKIE_SIZE = 4096;
 +    const MAX_NUM_COOKIES = 500;
 +    const MAX_COOKIE_SIZE = 40960;
      const EXPIRE_NOW_TIME = 1;
@@ -1031,11 +1034,12 @@ diff --git a/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderR
 index d419c25..eab39a4 100644
 --- a/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
 +++ b/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
-@@ -60,7 +60,7 @@ class SimplePolicyHeaderRenderer implements PolicyRendererInterface
+@@ -60,7 +60,8 @@ class SimplePolicyHeaderRenderer implements PolicyRendererInterface
          if ($existing = $response->getHeader($header)) {
              $value = $value .' ' .$existing->getFieldValue();
          }
 -        $response->setHeader($header, $value, true);
++        // patched by m2install
 +        //$response->setHeader($header, $value, true);
      }
 
@@ -1048,12 +1052,14 @@ diff --git a/vendor/magento/framework/App/Cache/Frontend/Pool.php b/vendor/magen
 index 6571ba7..0551b9f 100644
 --- a/vendor/magento/framework/App/Cache/Frontend/Pool.php
 +++ b/vendor/magento/framework/App/Cache/Frontend/Pool.php
-@@ -86,7 +86,7 @@ class Pool implements \Iterator
+@@ -86,7 +86,9 @@ class Pool implements \Iterator
           * default cache_dir setting from di.xml when a cache id_prefix is configured in app/etc/env.php.
           */
          $cacheInfo = $this->deploymentConfig->getConfigData(FrontendPool::KEY_CACHE);
 -        if (null !== $cacheInfo && array_key_exists(FrontendPool::KEY_FRONTEND_CACHE, $cacheInfo)) {
-+       if (null !== $cacheInfo && isset($cacheInfo[FrontendPool::KEY_FRONTEND_CACHE])) {
++        // patched by m2install
++        //if (null !== $cacheInfo && array_key_exists(FrontendPool::KEY_FRONTEND_CACHE, $cacheInfo)) {
++        if (null !== $cacheInfo && isset($cacheInfo[FrontendPool::KEY_FRONTEND_CACHE])) {
              return array_replace_recursive($this->_frontendSettings, $cacheInfo[FrontendPool::KEY_FRONTEND_CACHE]);
          }
          return $this->_frontendSettings;

--- a/m2install.sh
+++ b/m2install.sh
@@ -807,7 +807,7 @@ function restore_db()
 
     if [[ "${_DB_FILENAME}" =~ "db_mydumper.sql.gz" ]]; then
         hash myloader &>/dev/null || printError "'myloader' is not found on this system" || exit 1
-        CMD="gunzip -cf ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
+        CMD="cat ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
     else
         CMD="gunzip -cf ${_DB_FILENAME}"
         if which pv > /dev/null

--- a/m2install.sh
+++ b/m2install.sh
@@ -2820,7 +2820,7 @@ function parseMagentoVersion()
   else
     valueToParse="$(${BIN_PHP} bin/magento -V)"
   fi
-  echo "$valueToParse" | grep -oEh "[0-9\.-]+p*[0-9]*" | head -n1
+  echo "$valueToParse" | grep -oEh "([0-9](\.)?){2,3}(-p[0-9]{1,2})?" | head -n1
 }
 
 

--- a/m2install.sh
+++ b/m2install.sh
@@ -1871,8 +1871,7 @@ function getRecommendedSearchEngineForVersion()
     versionIsHigherThan "$(getMagentoVersion)" "2.3.0" && searchEngine="elasticsearch"
     versionIsHigherThan "$(getMagentoVersion)" "2.3.1" && searchEngine="elasticsearch5"
     versionIsHigherThan "$(getMagentoVersion)" "2.3.5" && searchEngine="elasticsearch7"
-    versionIsHigherThan "$(getMagentoVersion)" "2.4.2" && searchEngine="opensearch"
-    checkIfBasedOnDevelopBranch && searchEngine="opensearch"
+    checkIfBasedOnDevelopBranch && searchEngine="elasticsearch7"
     echo "$searchEngine"
     return 0
 }
@@ -1881,24 +1880,9 @@ function parseElasticSearchVersion()
 {
   local eshost=$1
   local esport=$2
-  local elasticSearchDistribution
-  local elasticSearchVersion
-
-  elasticSearchDistribution=$(curl -s "${eshost}:${esport}" | php -r 'print_r(json_decode(stream_get_contents(STDIN), true)["version"]["distribution"]);')
-  elasticSearchVersion=$(curl -s "${eshost}:${esport}" | php -r 'print_r(json_decode(stream_get_contents(STDIN), true)["version"]["version"]);')
-
-  case "${elasticSearchDistribution}" in
-    elasticsearch)
-      echo "elasticsearch${elasticSearchVersion}"
-      ;;
-    opensearch)
-      echo "opensearch"
-      ;;
-    *)
-      return 255
-      ;;
-  esac
-  return 0
+  local elasticSearchVersion=$(curl -s -X GET "$eshost:$esport" | grep number | sed 's/[^0-9.]//g' | head -c 1)
+  [[ "$elasticSearchVersion" ]] && [[ "$elasticSearchVersion" -gt 1 ]] && { echo "elasticsearch${elasticSearchVersion}"; return 0; }
+  return 255
 }
 
 function getESConfigHost()
@@ -1906,19 +1890,24 @@ function getESConfigHost()
   [[ "$ELASTICSEARCH_HOST" ]] && { echo "$ELASTICSEARCH_HOST"; return 0; }
   case "$1" in
     elasticsearch7)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH7_HOST";;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH7_HOST"
+      return 0
+      ;;
     elasticsearch6)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH6_HOST";;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH6_HOST"
+      return 0
+      ;;
     elasticsearch5)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH5_HOST";;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH5_HOST"
+      return 0
+      ;;
     elasticsearch)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH2_HOST";;
-    opensearch)
-      echo "$SEARCH_ENGINE_OPENSEARCH_HOST";;
-    *)
-      return 255;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH2_HOST"
+      return 0
+      ;;
   esac
-  return 0
+
+  return 255
 }
 
 function getESConfigPort()
@@ -1926,19 +1915,22 @@ function getESConfigPort()
   [[ "$ELASTICSEARCH_PORT" ]] && { echo "$ELASTICSEARCH_PORT"; return 0; }
   case "$1" in
     elasticsearch7)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH7_PORT";;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH7_PORT"
+      return 0
+      ;;
     elasticsearch6)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH6_PORT";;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH6_PORT"
+      return 0
+      ;;
     elasticsearch5)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH5_PORT";;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH5_PORT"
+      return 0
+      ;;
     elasticsearch)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH2_PORT";;
-    opensearch)
-      echo "$SEARCH_ENGINE_OPENSEARCH_PORT";;
-    *)
-      return 255;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH2_PORT"
+      return 0
+      ;;
   esac
-  return 0
 }
 
 function getMagentoVersion()
@@ -1987,18 +1979,13 @@ function downloadSourceCode()
 
 function composerInstall()
 {
-    if [ "$INSTALL_EE" ]; then
-        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-enterprise-edition ./ "${MAGENTO_VERSION}"
-        if (( $? != 0 )); then
-            echo "Failed to create a composer project"
-            exit 1
-        fi
+    if [ "$INSTALL_EE" ]
+    then
+        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition . ${MAGENTO_VERSION}"
+        runCommand
     else
-        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-community-edition ./ "${MAGENTO_VERSION}"
-        if (( $? != 0 )); then
-            echo "Failed to create a composer project"
-            exit 1
-        fi
+        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-community-edition . ${MAGENTO_VERSION}"
+        runCommand
     fi
 }
 
@@ -2817,31 +2804,6 @@ function testParseMagentoVersion()
   assertEqual "2.2.4-p10" "$result"
 }
 
-validateWorkDirectory() {
-  # Exit if the script runs inside a home directory
-  if [[ ${PWD} == ${HOME} ]]; then
-    echo "The script cannot be executed in home directory"
-    echo "Please create a subdirectory and run script from there"
-    exit 1
-  fi
-
-  # Sparta specific checks
-  if [[ ${HOSTNAME} =~ sparta.ceng.magento.com$ ]]; then
-    # Exit if the script runs outside of public_html directory
-    if [[ ! ${PWD} =~ ^${HOME}/public_html* ]]; then
-      echo "The script cannot be executed outside of public_html directory"
-      echo "Please create a subdirectory in ${HOME}/public_html and run script from there"
-      exit 1
-    fi
-
-    # Exit if the script runs inside public_html directory without a subfolder
-    if [[ ${PWD} == ${HOME}/public_html ]]; then
-      echo "The script cannot be executed in public_html directory"
-      echo "Please create a subdirectory and run script from there"
-      exit 1
-    fi
-  fi
-}
 
 ################################################################################
 # Main
@@ -2862,7 +2824,6 @@ function main()
     processOptions "$@"
     initQuietMode
     printString Current Directory: "$(pwd)"
-    validateWorkDirectory
     printString "Configuration loaded from: $(getConfigFiles)"
     checkDependencies
     showWizard

--- a/m2install.sh
+++ b/m2install.sh
@@ -1995,13 +1995,18 @@ function downloadSourceCode()
 
 function composerInstall()
 {
-    if [ "$INSTALL_EE" ]
-    then
-        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition . ${MAGENTO_VERSION}"
-        runCommand
+    if [ "$INSTALL_EE" ]; then
+        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-enterprise-edition ./ "${MAGENTO_VERSION}"
+        if (( $? != 0 )); then
+            echo "Failed to create a composer project"
+            exit 1
+        fi
     else
-        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-community-edition . ${MAGENTO_VERSION}"
-        runCommand
+        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-community-edition ./ "${MAGENTO_VERSION}"
+        if (( $? != 0 )); then
+            echo "Failed to create a composer project"
+            exit 1
+        fi
     fi
 }
 

--- a/m2install.sh
+++ b/m2install.sh
@@ -1024,6 +1024,23 @@ index 1f454518e43..b3dcc784917 100644
      const EXPIRE_NOW_TIME = 1;
      const EXPIRE_AT_END_OF_SESSION_TIME = 0;
 EOF
+  # Fix CSP issue
+  # https://wiki.corp.adobe.com/pages/viewpage.action?pageId=2998017599
+  patch -p1 <<'EOF'
+diff --git a/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php b/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
+index d419c25..eab39a4 100644
+--- a/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
++++ b/vendor/magento/module-csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
+@@ -60,7 +60,7 @@ class SimplePolicyHeaderRenderer implements PolicyRendererInterface
+         if ($existing = $response->getHeader($header)) {
+             $value = $value .' ' .$existing->getFieldValue();
+         }
+-        $response->setHeader($header, $value, true);
++        //$response->setHeader($header, $value, true);
+     }
+
+     /**
+EOF
 }
 
 function appConfigImport()

--- a/m2install.sh
+++ b/m2install.sh
@@ -1179,6 +1179,7 @@ function configure_db()
   setConfig 'web/secure/base_url' "${BASE_URL}";
   setConfig 'web/unsecure/base_url' "${BASE_URL}";
   setConfig 'web/secure/offloader_header' 'X-Forwarded-Proto';
+  setConfig 'web/seo/use_rewrites' '1';
   setConfig 'google/analytics/active' '0';
   setConfig 'google/adwords/active' '0';
   setConfig 'msp_securitysuite_twofactorauth/general/enabled' '0';

--- a/m2install.sh
+++ b/m2install.sh
@@ -2542,7 +2542,7 @@ function cleanupCurrentDirectory()
       runCommand
     elif askConfirmation "Do you want to keep dump files, ex: php*.code.tar.gz ? (y/N)";
     then
-      CMD="ls -I 'php*.*.*gz' -A | xargs rm -rf"
+      CMD="ls -I 'php*.*.*gz' -A | grep -v db_mydumper.sql.gz | xargs rm -rf"
       runCommand
     else
       CMD="$removeAll"

--- a/m2install.sh
+++ b/m2install.sh
@@ -1222,8 +1222,8 @@ function configure_db()
   switchSearchEngineToDefaultEngine
 
   ${BIN_PHP} ${BIN_MAGE} config:set 'web/seo/use_rewrites' '1'
-  ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_admin' '0'
-  ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_storefront' '0'
+  ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_admin' '2048000'
+  ${BIN_PHP} ${BIN_MAGE} config:set 'system/security/max_session_size_storefront' '2048000'
 }
 
 function setConfig()

--- a/m2install.sh
+++ b/m2install.sh
@@ -1881,9 +1881,24 @@ function parseElasticSearchVersion()
 {
   local eshost=$1
   local esport=$2
-  local elasticSearchVersion=$(curl -s -X GET "$eshost:$esport" | grep number | sed 's/[^0-9.]//g' | head -c 1)
-  [[ "$elasticSearchVersion" ]] && [[ "$elasticSearchVersion" -gt 1 ]] && { echo "elasticsearch${elasticSearchVersion}"; return 0; }
-  return 255
+  local elasticSearchDistribution
+  local elasticSearchVersion
+
+  elasticSearchDistribution=$(curl -s "${eshost}:${esport}" | php -r 'print_r(json_decode(stream_get_contents(STDIN), true)["version"]["distribution"]);')
+  elasticSearchVersion=$(curl -s "${eshost}:${esport}" | php -r 'print_r(json_decode(stream_get_contents(STDIN), true)["version"]["version"]);')
+
+  case "${elasticSearchDistribution}" in
+    elasticsearch)
+      echo "elasticsearch${elasticSearchVersion}"
+      ;;
+    opensearch)
+      echo "opensearch"
+      ;;
+    *)
+      return 255
+      ;;
+  esac
+  return 0
 }
 
 function getESConfigHost()

--- a/m2install.sh
+++ b/m2install.sh
@@ -2229,9 +2229,13 @@ function warmCache()
   local currentUser="$(whoami)"
   local dir="$(pwd)"
   local currentScript="$BASH_SOURCE"
+  local codebaseSize='\N'
+  local databaseSize='\N'
   if foundSupportBackupFiles
   then
     mode=restore
+    codebaseSize="$(stat --printf='%s' ${EXTRACT_FILENAME})"
+    databaseSize="$(stat --printf='%s' $(getDbDumpFilename))"
   fi
 
   END_TIME=$(date +%s)
@@ -2239,7 +2243,7 @@ function warmCache()
   printString "Cache warm up ${home_url}. Response code: $home_response_code"
   printString "Cache warm up ${admin_url}. Response code: $admin_response_code"
   printString "$(basename "$0") took $SUMMARY_TIME minutes to complete install/deploy process"
-  writeCsvMetricRow "$(date '+%Y-%m-%d %H:%M:%S'), $mode, $home_response_code, $home_url, $admin_response_code, $admin_url, $SUMMARY_TIME, $currentUser, $dir, $currentScript, \"$GLOBAL_ARGS\""
+  writeCsvMetricRow "$(date '+%Y-%m-%d %H:%M:%S'), $mode, $home_response_code, $home_url, $admin_response_code, $admin_url, $SUMMARY_TIME, $currentUser, $dir, $currentScript, \"$GLOBAL_ARGS\", $codebaseSize, $databaseSize"
 }
 
 function afterInstall()

--- a/m2install.sh
+++ b/m2install.sh
@@ -1871,7 +1871,8 @@ function getRecommendedSearchEngineForVersion()
     versionIsHigherThan "$(getMagentoVersion)" "2.3.0" && searchEngine="elasticsearch"
     versionIsHigherThan "$(getMagentoVersion)" "2.3.1" && searchEngine="elasticsearch5"
     versionIsHigherThan "$(getMagentoVersion)" "2.3.5" && searchEngine="elasticsearch7"
-    checkIfBasedOnDevelopBranch && searchEngine="elasticsearch7"
+    versionIsHigherThan "$(getMagentoVersion)" "2.4.2" && searchEngine="opensearch"
+    checkIfBasedOnDevelopBranch && searchEngine="opensearch"
     echo "$searchEngine"
     return 0
 }

--- a/m2install.sh
+++ b/m2install.sh
@@ -1906,24 +1906,19 @@ function getESConfigHost()
   [[ "$ELASTICSEARCH_HOST" ]] && { echo "$ELASTICSEARCH_HOST"; return 0; }
   case "$1" in
     elasticsearch7)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH7_HOST"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH7_HOST";;
     elasticsearch6)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH6_HOST"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH6_HOST";;
     elasticsearch5)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH5_HOST"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH5_HOST";;
     elasticsearch)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH2_HOST"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH2_HOST";;
+    opensearch)
+      echo "$SEARCH_ENGINE_OPENSEARCH_HOST";;
+    *)
+      return 255;;
   esac
-
-  return 255
+  return 0
 }
 
 function getESConfigPort()
@@ -1931,22 +1926,19 @@ function getESConfigPort()
   [[ "$ELASTICSEARCH_PORT" ]] && { echo "$ELASTICSEARCH_PORT"; return 0; }
   case "$1" in
     elasticsearch7)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH7_PORT"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH7_PORT";;
     elasticsearch6)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH6_PORT"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH6_PORT";;
     elasticsearch5)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH5_PORT"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH5_PORT";;
     elasticsearch)
-      echo "$SEARCH_ENGINE_ELASTICSEARCH2_PORT"
-      return 0
-      ;;
+      echo "$SEARCH_ENGINE_ELASTICSEARCH2_PORT";;
+    opensearch)
+      echo "$SEARCH_ENGINE_OPENSEARCH_PORT";;
+    *)
+      return 255;;
   esac
+  return 0
 }
 
 function getMagentoVersion()

--- a/m2install.sh
+++ b/m2install.sh
@@ -2476,7 +2476,6 @@ function processOptions()
         shift
     done
 }
-
 function cleanupCurrentDirectory()
 {
   local currentDirectory="$(pwd)"
@@ -2488,12 +2487,12 @@ function cleanupCurrentDirectory()
   fi
   if [ "$(ls -A)" ] && askConfirmation "Current directory is not empty. Do you want to clean current Directory (y/N)";
   then
-    if askConfirmation "Do you want to delete dump files? (y/N)";
+    if askConfirmation "Do you want to keep dump files, ex: php*.code.tar.gz ? (y/N)";
     then
-      CMD="ls -A | xargs rm -rf"
+      CMD="ls -I 'php*.*.*gz' -A | xargs rm -rf"
       runCommand
     else
-      CMD="ls -I 'php*.*.*gz' -A | xargs rm -rf"
+      CMD="ls -A | xargs rm -rf"
       runCommand
     fi
   fi

--- a/m2install.sh
+++ b/m2install.sh
@@ -807,7 +807,7 @@ function restore_db()
 
     if [[ "${_DB_FILENAME}" =~ "db_mydumper.sql.gz" ]]; then
         hash myloader &>/dev/null || printError "'myloader' is not found on this system" || exit 1
-        CMD="gunzip -cf ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --stream"
+        CMD="gunzip -cf ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
     else
         CMD="gunzip -cf ${_DB_FILENAME}"
         if which pv > /dev/null

--- a/m2install.sh
+++ b/m2install.sh
@@ -807,7 +807,7 @@ function restore_db()
 
     if [[ "${_DB_FILENAME}" =~ "db_mydumper.sql.gz" ]]; then
         hash myloader &>/dev/null || printError "'myloader' is not found on this system" || exit 1
-        CMD="cat ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
+        CMD="gunzip -cf ${_DB_FILENAME} | myloader --host ${DB_HOST} --user ${DB_USER} --password ${DB_PASSWORD} --database ${DB_NAME} --overwrite-tables --verbose 1 --stream"
     else
         CMD="gunzip -cf ${_DB_FILENAME}"
         if which pv > /dev/null

--- a/m2install.sh
+++ b/m2install.sh
@@ -986,6 +986,7 @@ function patchRemote()
 
 function patchDumps()
 {
+  # Fix issue with order grid in admin backend
   patch -p1 <<'EOF'
 diff --git a/vendor/magento/module-backend/Block/Dashboard/Orders/Grid.php b/vendor/magento/module-backend/Block/Dashboard/Orders/Grid.php
 index 5027978..9df3c24 100644
@@ -1003,6 +1004,25 @@ index 5027978..9df3c24 100644
              $item->getCustomer() ?: $item->setCustomer($item->getBillingAddress()->getName());
          }
          return $this;
+EOF
+  # Fix issue with large amount of cookies
+  # https://wiki.corp.adobe.com/pages/viewpage.action?pageId=2820824430
+  # https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/support-tools/patches/v1-0-12/mdva-12304-magento-patch-503-error-on-store-front-and-cookie-error
+  patch -p1 <<'EOF'
+diff -Nuar a/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php b/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
+index 1f454518e43..b3dcc784917 100644
+--- a/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
++++ b/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
+@@ -29,7 +29,7 @@ class PhpCookieManager implements CookieManagerInterface
+      * RFC 2109 - Page 15
+      * http://www.ietf.org/rfc/rfc6265.txt
+      */
+-    const MAX_NUM_COOKIES = 50;
+-    const MAX_COOKIE_SIZE = 4096;
++    const MAX_NUM_COOKIES = 500;
++    const MAX_COOKIE_SIZE = 40960;
+     const EXPIRE_NOW_TIME = 1;
+     const EXPIRE_AT_END_OF_SESSION_TIME = 0;
 EOF
 }
 

--- a/m2install.sh
+++ b/m2install.sh
@@ -1662,8 +1662,8 @@ function installLiveSearch()
 
   $BIN_PHP $BIN_MAGE module:status | grep -E 'Magento_Elasticsearch*|Magento_InventoryElasticsearch' | grep -v List | grep -v None | grep -v -e '^$' | xargs $BIN_PHP $BIN_MAGE module:disable
   $BIN_PHP $BIN_MAGE module:status | grep Magento_LiveSearch | grep -v List | grep -v None | grep -v -e '^$' | xargs $BIN_PHP $BIN_MAGE module:enable
+  $BIN_PHP $BIN_MAGE module:status | grep -E '.*QueryXml*|.*GraphQlServer*|.*ServicesId*|.*ServicesConnector*|.*DataExporter*|.*SaaS*|.*DataServices*'| xargs $BIN_PHP $BIN_MAGE  module:enable
   $BIN_PHP $BIN_MAGE --quiet config:set  'catalog/search/engine' NULL
-  $BIN_PHP $BIN_MAGE module:status | grep -E '.*ServicesId*|.*ServicesConnector*|.*DataExporter*|.*SaaS*|.*DataServices*'| xargs $BIN_PHP $BIN_MAGE  module:enable
   CMD="${BIN_PHP} ${BIN_MAGE} setup:upgrade"
   runCommand
   cat <<endmessage

--- a/m2install.sh
+++ b/m2install.sh
@@ -40,6 +40,7 @@ USE_SAMPLE_DATA=
 EE_PATH=magento2ee
 INSTALL_EE=
 INSTALL_B2B=
+INSTALL_PR=
 CONFIG_NAME=.m2install.conf
 USE_WIZARD=1
 
@@ -540,6 +541,10 @@ function noSourceWizard()
     then
          INSTALL_B2B=1
     fi
+    if askConfirmation "Do you want install Magento Product Recommendations (y/N)"
+    then
+         INSTALL_PR=1
+    fi
 }
 
 function printConfirmation()
@@ -592,6 +597,10 @@ function printConfirmation()
         printString "Magento B2B will be installed."
     else
         printString "Magento B2B will NOT be installed."
+    fi
+    if [ "${INSTALL_PR}" ]
+    then
+        printString "Magento Product Recommendations will be installed."
     fi
 }
 
@@ -676,6 +685,7 @@ DB_PASSWORD=$DB_PASSWORD
 MAGENTO_VERSION=$MAGENTO_VERSION
 INSTALL_EE=$INSTALL_EE
 INSTALL_B2B=$INSTALL_B2B
+INSTALL_PR=$INSTALL_PR
 GIT_CE_REPO=$GIT_CE_REPO
 GIT_EE_REPO=$GIT_EE_REPO
 MAGE_MODE=$MAGE_MODE
@@ -1681,6 +1691,24 @@ function installB2B()
     runCommand
 }
 
+function installPrex()
+{
+    CMD="${BIN_PHP} ${BIN_COMPOSER} require magento/product-recommendations"
+    runCommand
+
+    CMD="${BIN_PHP} ${BIN_MAGE} setup:upgrade"
+    runCommand
+    cat <<endmessage
+${yellow}
+####################################################################################
+Warning: Product Recommendations has been enabled.
+Please proceed to the API keys configuration and Catalog data synchronization:
+https://docs.magento.com/user-guide/configuration/services/saas.html
+####################################################################################
+${default}
+endmessage
+}
+
 function getB2Bversion()
 {
     checkIfBasedOnDevelopBranch && { B2B_VERSION="develop"; return 0; }
@@ -1953,7 +1981,10 @@ showComposerWizzard()
     then
         INSTALL_B2B=1
     fi
-
+    if askConfirmation "Do you want install Magento Product Recommendations (y/N)"
+    then
+        INSTALL_PR=1
+    fi
 }
 
 printComposerConfirmation()
@@ -1985,6 +2016,10 @@ function showWizzardGit()
     if [[ "$INSTALL_EE" ]] && askConfirmation "Do you want install B2B Extension (y/N)"
     then
         INSTALL_B2B=1
+    fi
+    if askConfirmation "Do you want install Magento Product Recommendations (y/N)"
+    then
+        INSTALL_PR=1
     fi
 }
 
@@ -2093,7 +2128,7 @@ function isInputNegative()
 function validateStep()
 {
     local _step=$1;
-    local _steps="restore_db restore_code configure_db configure_files configure installB2B installLiveSearch add_remote"
+    local _steps="restore_db restore_code configure_db configure_files configure installB2B installPrex add_remote"
     if echo "$_steps" | grep -q "$_step"
     then
         if type -t "$_step" &>/dev/null
@@ -2260,6 +2295,7 @@ Options:
     --sample-data (yes, no)              Install sample data.
     --ee                                 Install Enterprise Edition.
     --b2b                                Install B2B Extension.
+    --prex                               Install Product Recommendations.
     -v, --version                        Magento Version - it means: Composer version or GIT Branch
     --mode (dev, prod)                   Magento Mode. Dev mode does not generate static & di content.
     --quiet                              Quiet mode. Suppress output all commands
@@ -2268,6 +2304,7 @@ Options:
     --step (restore_code,restore_db      Specify step through comma without spaces.
         configure_db,configure_files     - Example: $(basename "$0") --step restore_db,configure_db
         installB2B --b2b                 - Example: $(basename "$0") --step installB2B --b2b
+        installPrex                      - Example: $(basename "$0") --step installPrex
         installLiveSearch)               - Example: $(basename "$0") --step installLiveSearch
     --restore-table                      Restore only the specific table from DB dumps
     --debug                              Enable debug mode
@@ -2327,6 +2364,9 @@ function processOptions()
                     B2B_VERSION="$2"
                     shift
                 fi
+            ;;
+            --prex)
+                INSTALL_PR=1
             ;;
             -b|--git-branch)
                 # @DEPRECATED. Use -v or --version instead
@@ -2480,6 +2520,10 @@ function magentoInstallAction()
     if [[ "$INSTALL_EE" ]] && [[ "$INSTALL_B2B" ]]
     then
         addStep "installB2B"
+    fi
+    if [[ "$INSTALL_PR" ]]
+    then
+        addStep "installPrex"
     fi
 }
 


### PR DESCRIPTION
This change fixes the regexp used for parsing Magento version. It fixes how dev versions like `Magento CLI dev-2.4-develop` get parsed.

Details: https://jira.corp.adobe.com/browse/L2ACIP-335